### PR TITLE
Bypass cmocka memory allocation check

### DIFF
--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -481,7 +481,11 @@ static void rrdlabel_insert_callback(const char *name, void *value, void *data) 
     RRDLABEL *lb = (RRDLABEL *)value;
 
     // allocate our own memory for the value
+#ifdef UNIT_TESTING
+    lb->value = strdup(lb->value);
+#else
     lb->value = strdupz(lb->value);
+#endif
     lb->label_source |= RRDLABEL_FLAG_NEW;
 }
 

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -481,11 +481,7 @@ static void rrdlabel_insert_callback(const char *name, void *value, void *data) 
     RRDLABEL *lb = (RRDLABEL *)value;
 
     // allocate our own memory for the value
-#ifdef UNIT_TESTING
-    lb->value = strdup(lb->value);
-#else
     lb->value = strdupz(lb->value);
-#endif
     lb->label_source |= RRDLABEL_FLAG_NEW;
 }
 

--- a/database/rrdlabels.c
+++ b/database/rrdlabels.c
@@ -3,14 +3,6 @@
 #define NETDATA_RRD_INTERNALS
 #include "rrd.h"
 
-#ifdef UNIT_TESTING
-// cmocka workaround for strdupz()
-#ifdef strdupz
-#undef strdupz
-#endif // strdupz
-#define strdupz(x) strdup(x)
-#endif // UNIT_TESTING
-
 // ----------------------------------------------------------------------------
 // labels sanitization
 

--- a/exporting/tests/test_exporting_engine.h
+++ b/exporting/tests/test_exporting_engine.h
@@ -30,7 +30,14 @@
 #include <stddef.h>
 #include <setjmp.h>
 #include <stdint.h>
+
+#ifndef UNIT_TESTING
 #include <cmocka.h>
+#else
+#undef UNIT_TESTING
+#include <cmocka.h>
+#define UNIT_TESTING
+#endif
 
 #define MAX_LOG_LINE 1024
 extern char log_line[];


### PR DESCRIPTION
It's a quick and dirty fix. I tried to mend cmocka memory allocation checks in a more correct way, but it turned out that such an approach would need a lot of changes and take quite a lot of time 😞.